### PR TITLE
Remove Liquid Append

### DIFF
--- a/packages/flux-vision/readme.md
+++ b/packages/flux-vision/readme.md
@@ -1,3 +1,28 @@
 # @adhawk/flux-vision
 
 Tracks end of funnel E-commerce data for your Shopify checkout. Gather in-depth analytics about product information, checkout steps viewed, purchase complete and more. Automatically integrated with Segment.io to allow you to send data to any number of destinations including Google Analytics, Google Tag Manager and more.
+
+## Liquid Template HTML
+
+To enable this package to pull liquid template data from Shopify into Segment, you must add this to the end of the `<body>` tag.
+
+```html
+<div id="FLUX_VISION_DATASETS" style="display:none">
+  <div
+    id="checkout-data"
+    data-checkout-id="{{checkout.id}}"
+    data-order-number="{{checkout.order_number}}"
+    data-total-price="{{checkout.total_price}}"
+  ></div>
+  {% for item in checkout.line_items %}
+  <div
+    id="product-item-for-analytics-dataset"
+    data-name="{{item.title}}"
+    data-sku="{{item.sku}}"
+    data-price="{{item.price}}"
+    data-quantity="{{item.quantity}}"
+    data-url="{{item.url}}"
+  ></div>
+  {% endfor %}
+</div>
+```

--- a/packages/flux-vision/src/__tests__/flux-vision.test.ts
+++ b/packages/flux-vision/src/__tests__/flux-vision.test.ts
@@ -9,6 +9,33 @@ describe("FluxVision", () => {
     }
   });
 
+  beforeEach(() => {
+    var data = document.querySelector("body");
+    data.insertAdjacentHTML(
+      "beforeend",
+      `
+          <div id="FLUX_VISION_DATASETS" style='display:none'> 
+              <div 
+                  id="checkout-data" 
+                  data-checkout-id={{checkout.id}} 
+                  data-order-number={{checkout.order_number}} 
+                  data-total-price={{checkout.total_price}} 
+              >
+              </div>
+              <div 
+                  id="product-item-for-analytics-dataset" 
+                  data-name="{{item.title}}" 
+                  data-sku="{{item.sku}}" 
+                  data-price="{{item.price}}" 
+                  data-quantity="{{item.quantity}}" 
+                  data-url="{{item.url}}" 
+              > 
+              </div>
+          </div>
+      `,
+    );
+  });
+
   it("initializes the class with analytics and shopify object", () => {
     const analytics = {
       track: jest.fn(),
@@ -173,5 +200,34 @@ describe("FluxVision", () => {
         ],
       });
     });
+  });
+});
+
+describe("Flux Vision Errors", () => {
+  beforeEach(() => {
+    var data = document.getElementById("FLUX_VISION_DATASETS");
+    if (data) {
+      data.remove();
+    }
+  });
+
+  it("throws an error if no div is found on the document", () => {
+    const analyticsTrackMock = jest.fn();
+    const analytics = {
+      track: analyticsTrackMock,
+    };
+
+    const Shopify = {
+      Checkout: { page: "thank_you", step: "processing" },
+    };
+
+    const flux = new FluxVision({ analytics, Shopify });
+    expect(() => {
+      flux.init();
+    }).toThrowError(
+      new Error(
+        "Flux Vision Error: no liquid element found with selector #FLUX_VISION_DATASETS. Learn more at https://github.com/adHawk/feathers/tree/master/packages/flux-vision",
+      ),
+    );
   });
 });

--- a/packages/flux-vision/src/flux-vision.ts
+++ b/packages/flux-vision/src/flux-vision.ts
@@ -4,45 +4,39 @@ export default class FluxVision {
   productData: any[];
   Shopify: any;
   analytics: any;
+  liquidDivSelector: string;
 
-  constructor({ analytics, Shopify }) {
+  constructor({
+    analytics,
+    Shopify,
+    liquidDivSelector = "#FLUX_VISION_DATASETS",
+  }) {
     this.productData = [];
     this.analytics = analytics;
     this.Shopify = Shopify;
+    this.liquidDivSelector = liquidDivSelector;
   }
 
   public init() {
-    this.addLiquidDivToDOM();
-    this.pullDataFromDOM();
-    this.sendAnalytics();
+    try {
+      this.checkDomForSelector();
+      this.pullDataFromDOM();
+      this.sendAnalytics();
+    } catch (error) {
+      throw new Error(`Flux Vision ${error}`);
+    }
   }
 
-  private addLiquidDivToDOM() {
-    const shopifyLiquidHTML = `
-    <div id="FLUX_VISION_DATASETS" style='display:none'> 
-        <div 
-            id="checkout-data" 
-            data-checkout-id={{checkout.id}} 
-            data-order-number={{checkout.order_number}} 
-            data-total-price={{checkout.total_price}} 
-        >
-        </div>
-    {% for item in checkout.line_items %} 
-        <div 
-            id="product-item-for-analytics-dataset" 
-            data-name="{{item.title}}" 
-            data-sku="{{item.sku}}" 
-            data-price="{{item.price}}" 
-            data-quantity="{{item.quantity}}" 
-            data-url="{{item.url}}" 
-        > 
-        </div>
-    {% endfor %}
-    </div>
-    `;
-
-    const body = document.querySelector("body");
-    body.insertAdjacentHTML("beforeend", shopifyLiquidHTML);
+  private checkDomForSelector() {
+    const { liquidDivSelector } = this;
+    try {
+      const liquidElement = document.querySelector(liquidDivSelector);
+      if (!liquidElement) {
+        throw `no liquid element found with selector ${liquidDivSelector}. Learn more at https://github.com/adHawk/feathers/tree/master/packages/flux-vision`;
+      }
+    } catch (error) {
+      throw new Error(error);
+    }
   }
 
   private pullDataFromDOM() {


### PR DESCRIPTION
Some unexpected bugs cropped up as a result of using liquid. 

It turns out that the html needs to be present on the dom for liquid to correctly populate the data in the dataset divs. 

This PR moves that logic into the documentation and adds some error handling to display helpful messaging and links to the docs to aid in debugging. 
