### PR TITLE
Add ability to override analytics config

### DIFF
--- a/packages/analytics-pixel-loader/src/__tests__/analytics-pixel-loader.test.ts
+++ b/packages/analytics-pixel-loader/src/__tests__/analytics-pixel-loader.test.ts
@@ -17,7 +17,16 @@ describe("Analytics Pixel Loader", () => {
       var analytics = new Analytics();
       analytics.VERSION = require('@segment/analytics.js-core/package.json').version;
       analytics.use(GoogleAnalytics);
-      analytics.initialize({\\"Google Analytics\\":{\\"trackingId\\":\\"UA-123\\"}});
+      var analyticsConfig = {\\"Google Analytics\\":{\\"trackingId\\":\\"UA-123\\"}};
+
+      if (typeof document !== 'undefined') {
+        var analyticsConfigMeta = document.querySelector('meta[name=\\"analytics-config\\"]');
+        if (analyticsConfigMeta) {
+          analyticsConfig = JSON.parse(analyticsConfigMeta.content);
+        }
+      }
+
+      analytics.initialize(analyticsConfig);
       export default analytics;"
     `);
   });
@@ -39,7 +48,16 @@ describe("Analytics Pixel Loader", () => {
       var analytics = new Analytics();
       analytics.VERSION = require('@segment/analytics.js-core/package.json').version;
       analytics.use(GoogleAnalytics);
-      analytics.initialize({\\"Google Analytics\\":{\\"trackingId\\":\\"UA-123\\"}});
+      var analyticsConfig = {\\"Google Analytics\\":{\\"trackingId\\":\\"UA-123\\"}};
+
+      if (typeof document !== 'undefined') {
+        var analyticsConfigMeta = document.querySelector('meta[name=\\"analytics-config\\"]');
+        if (analyticsConfigMeta) {
+          analyticsConfig = JSON.parse(analyticsConfigMeta.content);
+        }
+      }
+
+      analytics.initialize(analyticsConfig);
       export default analytics;"
     `);
   });

--- a/packages/analytics-pixel-loader/src/index.ts
+++ b/packages/analytics-pixel-loader/src/index.ts
@@ -53,15 +53,22 @@ export default function(source: string) {
     mappedAnalyticsConfig[integration.name] = integration.opts;
   }
 
-  const outputSource = [
-    ...imports,
-    "var Analytics = require('@segment/analytics.js-core/lib/analytics');",
-    "var analytics = new Analytics();",
-    "analytics.VERSION = require('@segment/analytics.js-core/package.json').version;",
-    ...setups,
-    `analytics.initialize(${JSON.stringify(mappedAnalyticsConfig)});`,
-    "export default analytics;"
-  ].join("\n");
+  const outputSource = `${imports.join("\n")}
+var Analytics = require('@segment/analytics.js-core/lib/analytics');
+var analytics = new Analytics();
+analytics.VERSION = require('@segment/analytics.js-core/package.json').version;
+${setups.join("\n")}
+var analyticsConfig = ${JSON.stringify(mappedAnalyticsConfig)};
+
+if (typeof document !== 'undefined') {
+  var analyticsConfigMeta = document.querySelector('meta[name="analytics-config"]');
+  if (analyticsConfigMeta) {
+    analyticsConfig = JSON.parse(analyticsConfigMeta.content);
+  }
+}
+
+analytics.initialize(analyticsConfig);
+export default analytics;`;
 
   return outputSource;
 }


### PR DESCRIPTION
This PR adds the ability to override a page's analytics config by specificing a meta tag:

```html
<meta name="analytics-config" content='{"Google Analytics": {"trackingId": "123"}}'>
```

This will allow for things like conditional disabling for admin users, etc.