### PR TITLE
Add Event Purchase to Order Complete

### DIFF
--- a/packages/flux-vision/package.json
+++ b/packages/flux-vision/package.json
@@ -42,5 +42,6 @@
   "devDependencies": {
     "jest-environment-jsdom": "^25.1.0",
     "typescript": "^3.1.3"
-  }
+  },
+  "gitHead": "cc8d31ae35832bec2879b2f364fcb4cb60345932"
 }

--- a/packages/gtm-enhanced/src/__tests__/gtm-enhanced.test.ts
+++ b/packages/gtm-enhanced/src/__tests__/gtm-enhanced.test.ts
@@ -278,6 +278,7 @@ describe("GTM Enhanced", () => {
             userId: 1,
             segmentAnonymousId: anonId,
             ecommerce: {
+              event: "purchase",
               purchase: {
                 actionField: {
                   id: "50314b8e9bcf000000000000",

--- a/packages/gtm-enhanced/src/__tests__/gtm-enhanced.test.ts
+++ b/packages/gtm-enhanced/src/__tests__/gtm-enhanced.test.ts
@@ -277,8 +277,8 @@ describe("GTM Enhanced", () => {
           expect.objectContaining({
             userId: 1,
             segmentAnonymousId: anonId,
+            event: "purchase",
             ecommerce: {
-              event: "purchase",
               purchase: {
                 actionField: {
                   id: "50314b8e9bcf000000000000",

--- a/packages/gtm-enhanced/src/index.ts
+++ b/packages/gtm-enhanced/src/index.ts
@@ -212,6 +212,7 @@ EnhancedGTM.prototype.orderCompleted = function(track) {
   push({
     ...userProps,
     ecommerce: {
+      event: "purchase",
       purchase: {
         actionField: {
           id: track.orderId(),

--- a/packages/gtm-enhanced/src/index.ts
+++ b/packages/gtm-enhanced/src/index.ts
@@ -211,8 +211,8 @@ EnhancedGTM.prototype.orderCompleted = function(track) {
 
   push({
     ...userProps,
+    event: "purchase",
     ecommerce: {
-      event: "purchase",
       purchase: {
         actionField: {
           id: track.orderId(),


### PR DESCRIPTION
GTM-Enhanced Update

This PR adds `event:"purchase"` to the orderComplete spec for Segment -> GTM translation. Allowing GTM to pick this event up by tag. 

Doez Tom De Moya have a github?
