### PR TITLE
Add check for order status page

### DIFF
--- a/packages/flux-vision/src/__tests__/flux-vision.test.ts
+++ b/packages/flux-vision/src/__tests__/flux-vision.test.ts
@@ -170,7 +170,7 @@ describe("FluxVision", () => {
       });
     });
 
-    it("sends the correct event for purchase", () => {
+    it("sends the correct event for purchase if Shopify.Checkout.page is 'thank_you'", () => {
       const analyticsTrackMock = jest.fn();
       const analytics = {
         track: analyticsTrackMock,
@@ -178,6 +178,41 @@ describe("FluxVision", () => {
 
       const Shopify = {
         Checkout: { page: "thank_you", step: "processing" },
+      };
+
+      const flux = new FluxVision({ analytics, Shopify });
+      flux.init();
+
+      expect(analyticsTrackMock).toHaveBeenCalledTimes(1);
+      expect(analyticsTrackMock).toHaveBeenCalledWith("Order Completed", {
+        checkout_id: "{{checkout.id}}",
+        currency: "USD",
+        order_id: "{{checkout.order_number}}",
+        total: "{{checkout.total_price}}",
+        products: [
+          {
+            name: "{{item.title}}",
+            price: "NaN",
+            quantity: "{{item.quantity}}",
+            sku: "{{item.sku}}",
+            url: "{{item.url}}",
+          },
+        ],
+      });
+    });
+
+    it("sends the correct event for purchase if Shopify.Checkout.isOrderStatusPage is true", () => {
+      const analyticsTrackMock = jest.fn();
+      const analytics = {
+        track: analyticsTrackMock,
+      };
+
+      const Shopify = {
+        Checkout: {
+          page: undefined,
+          step: "processing",
+          isOrderStatusPage: true,
+        },
       };
 
       const flux = new FluxVision({ analytics, Shopify });

--- a/packages/flux-vision/src/flux-vision.ts
+++ b/packages/flux-vision/src/flux-vision.ts
@@ -64,7 +64,11 @@ export default class FluxVision {
 
   private sendAnalytics() {
     const { analytics, checkoutDataset, productData } = this;
-    const { currentStep, currentPage } = this.getCurrentEnvironment();
+    const {
+      currentStep,
+      currentPage,
+      isOrderStatusPage,
+    } = this.getCurrentEnvironment();
 
     switch (currentStep) {
       case "contact_information":
@@ -93,7 +97,7 @@ export default class FluxVision {
         break;
     }
 
-    if (currentPage == "thank_you") {
+    if (currentPage == "thank_you" || isOrderStatusPage) {
       analytics.track("Order Completed", {
         checkout_id: checkoutDataset.checkoutId,
         order_id: checkoutDataset.orderNumber,
@@ -110,6 +114,7 @@ export default class FluxVision {
     return {
       currentStep: Shopify.Checkout.step,
       currentPage: Shopify.Checkout.page,
+      isOrderStatusPage: Shopify.Checkout.isOrderStatusPage,
     };
   }
 }


### PR DESCRIPTION
Shopify window.Shopify object behavior is unreliable on the final checkout page. We want to make sure we're sending purchase events, so this PR sets the condition for this event to rely on a few page parameters.

Shopify documented behavior:
[Documentation here on checkout objects](https://shopify.dev/tutorials/develop-theme-layouts-checkout
)
`While the “Order Status” page can be considered a “checkout” page, the Shopify.Checkout.step and Shopify.Checkout.page objects are only defined here the first time you land on the page; at this point, it’s a “Thank You” page. If the customer revisits or reloads the page, this “checkout” is converted to an “order”, and the page loads as an “Order Status” page.`

Actual Behavior: 
The final checkout page will sometimes set Shopify.Checkout.page = "thank_you" and other times that value will be undefined. Even when I tested added separate products to my cart and checking out, the Shopify.Checkout.page is sometimes set to 'thank_you' and other times `undefined` on completely separate cart orders with different products.

The only other value available to us is the Shopify.Checkout.isOrderStatusPage which seems to be much more reliable that relying on Shopify.Checkout.page alone. 

_Note_: The downside to relying on the Shopify.Checkout.isOrderStatusPage variable is that a user might come back to the order status page or reload the page, which might send another purchase event. 